### PR TITLE
Remove Ruby 1.9.3 from deploy-time testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Removed
+- Ruby 1.9.3 from deploy-time testing (@eheydrick)
 
 ## [1.0.0] - 2017-06-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Sensu-Plugins-golang
 
-[ ![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-golang.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-golang)
+[![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-golang.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-golang)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-golang.svg)](http://badge.fury.io/rb/sensu-plugins-golang)
 [![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-golang/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-golang)
 [![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-golang/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-golang)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass 

#### Purpose

No longer supporting 1.9.3 so remove deploy-time testing.
